### PR TITLE
Proper NSApplicationDelegate Selectors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,12 +103,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApplication.shared().terminate(self)
     }
 
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         statusItem.title = "WeatherBar"
         statusItem.menu = statusMenu
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 
@@ -200,10 +200,10 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 }


### PR DESCRIPTION
This provides a fix for Issue #11. In the initial part of the current version of the tutorial, it instructs you to use the symbol:

```swift
func applicationDidFinishLaunching(aNotification: NSNotification) {
```

However, the correct symbol from the `NSApplicationDelegate` protocol is:

```swift
func applicationDidFinishLaunching(_ aNotification: Notification) {
```

Notice the underscore for the argument label in the 2nd example, which is the difference between the method signature being `applicationDidFinishLaunching(aNotification:)` and `applicationDidFinishLaunching(_:)`. This is probably an artifact of running the Swift Migration Tool on an older version of the language, but it prevented the expected method from ever being called by macOS, so the status bar item would never show. This PR changes it to what it *should* be, so the code within runs properly and the status bar item functions properly in this part of the tutorial. I also fixed the same problem with `applicationWillTerminate`, though that method is never used in the tutorial